### PR TITLE
Clone data to prevent write errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,8 +60,9 @@ internals.GoodLoggly.getMessage = function (event) {
         '';
 };
 
-internals.GoodLoggly.prototype._report = function (data) {
-
+internals.GoodLoggly.prototype._report = function (report) {
+    var data = Hoek.clone(report);
+    
     // Map hapi event data fields to Loggly fields
     if (this._config.name)     { data.name     = this._config.name; }
     if (this._config.hostname) { data.hostname = this._config.hostname; }


### PR DESCRIPTION
Otherwise, I was getting `TypeError: Cannot assign to read only property 'timestamp' of [object Object]`