### PR TITLE
Fix readme missing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var options = {
             subdomain : 'YOUR LOGGLY SUBDOMAIN',
             // Optional
             name      : 'myapp',
-            hostname  : 'myapp.example.com'
+            hostname  : 'myapp.example.com',
             tags      : ['global', 'tags', 'for', 'all', 'requests']
         }
     }]


### PR DESCRIPTION
Fixes a minor typo, which causes a syntax error if the user copy & pastes the example from the readme.